### PR TITLE
int -> int32

### DIFF
--- a/lib/Net/FTP/System.pm6
+++ b/lib/Net/FTP/System.pm6
@@ -3,7 +3,7 @@ use NativeCall;
 
 unit module Net::FTP::System;
 
-sub time () returns int is native('libc.so.6') is export { * }
+sub time () returns int32 is native('libc.so.6') is export { * }
 
 class tm is repr('CStruct') is export {
 	has int $.sec;


### PR DESCRIPTION
This should take care of the following warning when installing:  
```
Potential difficulties:
    The returning type of 'time' --> int is erroneous. You should not return a non NativeCall supported type (like Int inplace of int32), truncating errors can appear with different architectures
    at /home/kmel/Desktop/.panda-work/1461612228_1/site#sources/3DF05EED86A415758A97DEF65481B9161B7B4333 (Net::FTP::System):8
    ------> t is native('libc.so.6') is export { * }⏏<EOL>
```