### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name" : "Net::FTP",
+    "license" : "Artistic-2.0",
     "version" : "0.6.1",
     "description" : "A ftp client written in perl6",
     "author" : "loren",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license