### PR TITLE
Fix module on some Rakudos

### DIFF
--- a/lib/Net/FTP/Transfer.pm6
+++ b/lib/Net/FTP/Transfer.pm6
@@ -12,7 +12,7 @@ has $.ascii;
 #	%args
 #	host port passive ascii family encoding
 method new (*%args) {
-	%args<listen> = !%args<passive>;
+	%args<listen> = True if !%args<passive>;
     %args<input-line-separator> = "\r\n";
 	self.bless(|%args);
 }


### PR DESCRIPTION
Bug was addressed in https://github.com/rakudo/rakudo/issues/1738
and introduced about a year prior. This fixes breakage in 
that year worth of Rakudo versions.